### PR TITLE
Refactor: Replace DataContext with IDataContext for Dependency Injection

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,5 +97,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      # with:
+        # category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp', 'javascript' ]
+        language: [ 'csharp', 'javascript-typescript' ]
         # ###language: [ 'csharp', 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both

--- a/Ezenity.API/Ezenity.API.xml
+++ b/Ezenity.API/Ezenity.API.xml
@@ -677,7 +677,7 @@
             Application settings for configuring JWT.
             </summary>
         </member>
-        <member name="M:Ezenity.API.Middleware.CustomJwtAuthenticationHandler.#ctor(Microsoft.Extensions.Options.IOptionsMonitor{Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions},Microsoft.Extensions.Options.IOptions{Ezenity.Infrastructure.Helpers.AppSettings},Microsoft.Extensions.Logging.ILoggerFactory,System.Text.Encodings.Web.UrlEncoder,Microsoft.AspNetCore.Authentication.ISystemClock,Ezenity.Infrastructure.Helpers.DataContext)">
+        <member name="M:Ezenity.API.Middleware.CustomJwtAuthenticationHandler.#ctor(Microsoft.Extensions.Options.IOptionsMonitor{Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions},Ezenity.Core.Interfaces.IAppSettings,Microsoft.Extensions.Logging.ILoggerFactory,System.Text.Encodings.Web.UrlEncoder,Microsoft.AspNetCore.Authentication.ISystemClock,Ezenity.Infrastructure.Helpers.DataContext)">
             <summary>
             Initializes a new instance of the <see cref="T:Ezenity.API.Middleware.CustomJwtAuthenticationHandler"/> class.
             </summary>
@@ -732,8 +732,7 @@
             Application settings for configuring JWT.
             </summary>
         </member>
-
-        <member name="M:Ezenity.API.Middleware.JwtMiddleware.#ctor(Microsoft.AspNetCore.Http.RequestDelegate,Microsoft.Ext        <member name="M:Ezenity.API.Middleware.JwtMiddleware.#ctor(Microsoft.AspNetCore.Http.RequestDelegate,Ezenity.Core.Interfaces.IAppSettings)">
+        <member name="M:Ezenity.API.Middleware.JwtMiddleware.#ctor(Microsoft.AspNetCore.Http.RequestDelegate,Ezenity.Core.Interfaces.IAppSettings)">
             <summary>
             Initializes a new instance of the <see cref="T:Ezenity.API.Middleware.JwtMiddleware"/> class.
             </summary>

--- a/Ezenity.API/Filters/LoadAccountFilter.cs
+++ b/Ezenity.API/Filters/LoadAccountFilter.cs
@@ -1,4 +1,4 @@
-﻿using Ezenity.Infrastructure.Helpers;
+﻿using Ezenity.Core.Interfaces;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
@@ -14,13 +14,13 @@ namespace Ezenity.API.Filters
         /// <summary>
         /// The database context used for retrieving the account data.
         /// </summary>
-        private readonly DataContext _context;
+        private readonly IDataContext _context;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoadAccountFilter"/> class.
         /// </summary>
         /// <param name="context">The database context.</param>
-        public LoadAccountFilter(DataContext context)
+        public LoadAccountFilter(IDataContext context)
         {
             _context = context;
         }

--- a/Ezenity.API/Middleware/CustomJwtAuthenticationHandler.cs
+++ b/Ezenity.API/Middleware/CustomJwtAuthenticationHandler.cs
@@ -29,7 +29,7 @@ namespace Ezenity.API.Middleware
         /// Application settings for configuring JWT.
         /// </summary>
         private readonly IAppSettings _appSettings;
-        private readonly DataContext _context;
+        private readonly IDataContext _context;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomJwtAuthenticationHandler"/> class.
@@ -46,7 +46,7 @@ namespace Ezenity.API.Middleware
             ILoggerFactory logger,
             UrlEncoder encoder,
             ISystemClock clock,
-            DataContext context)
+            IDataContext context)
             : base(options, logger, encoder, clock)
         {
             _appSettings = appSettings;

--- a/Ezenity.API/Middleware/JwtMiddleware.cs
+++ b/Ezenity.API/Middleware/JwtMiddleware.cs
@@ -43,7 +43,7 @@ namespace Ezenity.API.Middleware
         /// <param name="context">The HTTP context for the current request and response.</param>
         /// <param name="dataContext">The database context to query for accounts.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task Invoke(HttpContext context, DataContext dataContext)
+        public async Task Invoke(HttpContext context, IDataContext dataContext)
         {
             var token = context.Request.Headers["Authorization"].FirstOrDefault()?.Split(" ").Last();
 
@@ -60,7 +60,7 @@ namespace Ezenity.API.Middleware
         /// <param name="dataContext">The database context to query for accounts.</param>
         /// <param name="token">The JWT to validate and extract account information from.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        private async Task attachAccountToContext(HttpContext context, DataContext dataContext, string token)
+        private async Task attachAccountToContext(HttpContext context, IDataContext dataContext, string token)
         {
             try
             {

--- a/Ezenity.Infrastructure/Helpers/EmailHelpers.cs
+++ b/Ezenity.Infrastructure/Helpers/EmailHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using Ezenity.Core.Entities.EmailTemplates;
+using Ezenity.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -64,7 +65,7 @@ namespace Ezenity.Infrastructure.Helpers
         /// <param name="templateName">Name of the template.</param>
         /// <param name="context">The data context.</param>
         /// <returns>The EmailTemplate object if found; otherwise, null.</returns>
-        public static EmailTemplate GetEmailTemplateByName(string templateName, DataContext context)
+        public static EmailTemplate GetEmailTemplateByName(string templateName, IDataContext context)
         {
             return context.EmailTemplates.FirstOrDefault(t => t.TemplateName == templateName);
         }

--- a/Ezenity.Infrastructure/Services/BaseService.cs
+++ b/Ezenity.Infrastructure/Services/BaseService.cs
@@ -18,7 +18,7 @@ namespace Ezenity.Infrastructure.Services
         /// <summary>
         /// The data context used for database operations.
         /// </summary>
-        protected readonly DataContext _context;
+        protected readonly IDataContext _context;
 
         /// <summary>
         /// The AutoMapper instance used for object-object mapping.
@@ -36,7 +36,7 @@ namespace Ezenity.Infrastructure.Services
         /// <param name="context">The data context.</param>
         /// <param name="mapper">The AutoMapper instance.</param>
         /// <param name="appSettings">The application settings.</param>
-        public BaseService(DataContext context, IMapper mapper, IAppSettings appSettings)
+        public BaseService(IDataContext context, IMapper mapper, IAppSettings appSettings)
         {
             _context = context ?? throw new ArgumentException(nameof(context));
             _mapper = mapper ?? throw new ArgumentException(nameof(mapper));

--- a/Ezenity.Infrastructure/Services/Emails/EmailService.cs
+++ b/Ezenity.Infrastructure/Services/Emails/EmailService.cs
@@ -29,7 +29,7 @@ namespace Ezenity.Infrastructure.Services.Emails
         /// <summary>
         /// The data context used for database operations.
         /// </summary>
-        private readonly DataContext _context;
+        private readonly IDataContext _context;
 
         /// <summary>
         /// Provides details about the web hosting environment an application is running in.
@@ -42,7 +42,7 @@ namespace Ezenity.Infrastructure.Services.Emails
         /// <param name="appSettings">Application settings.</param>
         /// <param name="context">Data context for database operations.</param>
         /// <param name="env">Web hosting environment details.</param>
-        public EmailService(IAppSettings appSettings, DataContext context, IWebHostEnvironment env)
+        public EmailService(IAppSettings appSettings, IDataContext context, IWebHostEnvironment env)
         {
             _appSettings = appSettings ?? throw new ArgumentException(nameof(appSettings));
             _context = context ?? throw new ArgumentException(nameof(context));

--- a/Ezenity.Infrastructure/Services/Sections/SectionService.cs
+++ b/Ezenity.Infrastructure/Services/Sections/SectionService.cs
@@ -25,7 +25,7 @@ namespace Ezenity.Infrastructure.Services.Sections
         /// <summary>
         /// Provides data access to the application's data store.
         /// </summary>
-        private readonly DataContext _context;
+        private readonly IDataContext _context;
 
         /// <summary>
         /// Provides object-object mapping functionality.
@@ -49,7 +49,7 @@ namespace Ezenity.Infrastructure.Services.Sections
         /// <param name="mapper">Object mapper for model transformation.</param>
         /// <param name="appSettings">Application settings.</param>
         /// <param name="logger">Logger instance.</param>
-        public SectionService(DataContext context, IMapper mapper, IAppSettings appSettings, ILogger<ISectionService> logger)
+        public SectionService(IDataContext context, IMapper mapper, IAppSettings appSettings, ILogger<ISectionService> logger)
         {
             _context = context ?? throw new ArgumentException(nameof(context));
             _mapper = mapper ?? throw new ArgumentException(nameof(mapper));


### PR DESCRIPTION
This commit focuses on enhancing the modularity and testability of the code:

1. Replaced all private variables that were using the concrete 'DataContext' class with its corresponding 'IDataContext' interface within constructors. This is in alignment with Dependency Injection best practices.

By making these changes, the application is now more adaptable and easier to unit test.