### PR TITLE
Fix: Sanitize IP address to prevent log injection (#47)

### DIFF
--- a/Ezenity.API/Controllers/AccountsController.cs
+++ b/Ezenity.API/Controllers/AccountsController.cs
@@ -642,7 +642,10 @@ namespace Ezenity.API.API.Controllers
                 apiResponse.IsSuccess = true;
                 apiResponse.Data = response;
 
-                _logger.LogInformation("Token refreshed successfully for IP: {0}", ipAddress());
+                // Sanitize the IP address by removing new lines and non-numeric or common characters
+                string sanitizedIp = System.Text.RegularExpressions.Regex.Replace(ipAddress(), "[^0-9.]", "");
+
+                _logger.LogInformation($"Token refreshed successfully for IP: {sanitizedIp}");
 
                 return Ok(apiResponse);
             }


### PR DESCRIPTION
Fixes #47

- Implement regular expression to remove non-numeric and uncommon characters from the IP address.
- This mitigates the risk of log injection by sanitizing the user-provided IP address before logging it.