### PR TITLE
Fix ErrorHandlerMiddleware IAppSettings Injection (#59) (#60)

### DIFF
--- a/Ezenity.API/Ezenity.API.xml
+++ b/Ezenity.API/Ezenity.API.xml
@@ -649,7 +649,7 @@
             JSON:API compliant HTTP responses. It logs errors and provides a consistent error handling strategy.
             </summary>
         </member>
-        <member name="M:Ezenity.API.Middleware.ErrorHandlerMiddleware.#ctor(Microsoft.AspNetCore.Http.RequestDelegate,Microsoft.Extensions.Logging.ILogger{Ezenity.API.Middleware.ErrorHandlerMiddleware},Microsoft.Extensions.Options.IOptions{Ezenity.Core.Interfaces.IAppSettings},Ezenity.Core.Interfaces.ISensitivePropertiesSettings)">
+        <member name="M:Ezenity.API.Middleware.ErrorHandlerMiddleware.#ctor(Microsoft.AspNetCore.Http.RequestDelegate,Microsoft.Extensions.Logging.ILogger{Ezenity.API.Middleware.ErrorHandlerMiddleware},Ezenity.Core.Interfaces.IAppSettings,Ezenity.Core.Interfaces.ISensitivePropertiesSettings)">
             <summary>
             Initializes a new instance of the ErrorHandlerMiddleware class with dependencies.
             </summary>

--- a/Ezenity.API/Middleware/ErrorHandlerMiddleware.cs
+++ b/Ezenity.API/Middleware/ErrorHandlerMiddleware.cs
@@ -35,12 +35,16 @@ namespace Ezenity.API.Middleware
         public ErrorHandlerMiddleware(
             RequestDelegate next,
             ILogger<ErrorHandlerMiddleware> logger,
-            IOptions<IAppSettings> appSettings,
+            // IOptions<IAppSettings> appSettings, // Causing a 'MissingMethodException'
+            // IOptionsSnapshot<IAppSettings> appSettings, // Can update configuration data when the application reads the data.
+            // IOptionsMonitor<IAppSettings> appSettings, // Provides a change notification when the 'IAppSettings' data changes.
+            IAppSettings appSettings, // Directly injecting IAppSetings
             ISensitivePropertiesSettings sensitivePropertiesSettings)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _appSettings = appSettings?.Value ?? throw new ArgumentNullException(nameof(appSettings));
+            // _appSettings = appSettings?.Value ?? throw new ArgumentNullException(nameof(appSettings)); Used for IOptions...
+            _appSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
             _sensitivePropertiesSettings = sensitivePropertiesSettings ?? throw new ArgumentNullException(nameof(sensitivePropertiesSettings));
         }
 


### PR DESCRIPTION
* Fix ErrorHandlerMiddleware IAppSettings Injection

Resolved the 'System.MissingMethodException' by correcting the dependency injection of IAppSettings in ErrorHandlerMiddleware. Removed the use of IOptions wrapper and directly injected IAppSettings, eliminating the erroneous use of '.Value' property. This change ensures that the middleware correctly receives and utilizes the application settings.

- Refactored ErrorHandlerMiddleware constructor to accept IAppSettings directly.
- Removed the .Value property access, which was applicable only for IOptions<IAppSettings>.
- Updated ErrorHandlerMiddleware comments to reflect the changes and improve code documentation.

* Removing sensitive file and update .gitignore